### PR TITLE
Fix generator for recursive structures.

### DIFF
--- a/generator/processor_test.go
+++ b/generator/processor_test.go
@@ -1,0 +1,76 @@
+package generator_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"golang.org/x/tools/go/types"
+
+	"github.com/tyba/storable/generator"
+)
+
+func TestRecursiveStruct(t *testing.T) {
+	fixtureSrc := `
+	package fixture
+
+	import 	"github.com/tyba/storable"
+
+	type Recur struct {
+		storable.Document
+		Foo string
+		R *Recur
+	}
+	`
+
+	fset := &token.FileSet{}
+	astFile, _ := parser.ParseFile(fset, "fixture.go", fixtureSrc, 0)
+	cfg := &types.Config{}
+	p, _ := cfg.Check("github.com/tcard/navpatch/navpatch", fset, []*ast.File{astFile}, nil)
+
+	prc := generator.NewProcessor("fixture", nil)
+	genPkg, err := prc.ProcessTypesPkg(p)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if genPkg.Models[0].Fields[2].Fields[2] != genPkg.Models[0].Fields[2] {
+		t.Fatalf("direct type recursivity not handled correctly.")
+	}
+}
+
+func TestDeepRecursiveStruct(t *testing.T) {
+	fixtureSrc := `
+	package fixture
+
+	import 	"github.com/tyba/storable"
+
+	type Recur struct {
+		storable.Document
+		Foo string
+		R *Other
+	}
+
+	type Other struct {
+		R *Recur
+	}
+	`
+
+	fset := &token.FileSet{}
+	astFile, _ := parser.ParseFile(fset, "fixture.go", fixtureSrc, 0)
+	cfg := &types.Config{}
+	p, _ := cfg.Check("github.com/tcard/navpatch/navpatch", fset, []*ast.File{astFile}, nil)
+
+	prc := generator.NewProcessor("fixture", nil)
+	genPkg, err := prc.ProcessTypesPkg(p)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if genPkg.Models[0].Fields[2].Fields[0].Fields[2] != genPkg.Models[0].Fields[2] {
+		t.Fatalf("indirect type recursivity not handled correctly.")
+	}
+}

--- a/generator/types.go
+++ b/generator/types.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+
+	"golang.org/x/tools/go/types"
 )
 
 var findableTypes = map[string]bool{
@@ -113,12 +115,13 @@ func NewFunction() {
 }
 
 type Field struct {
-	Name   string
-	Type   string
-	Tag    reflect.StructTag
-	Fields []*Field
-	Parent *Field
-	isMap  bool
+	Name        string
+	Type        string
+	CheckedNode *types.Var
+	Tag         reflect.StructTag
+	Fields      []*Field
+	Parent      *Field
+	isMap       bool
 }
 
 func NewField(n, t string, tag reflect.StructTag) *Field {
@@ -212,9 +215,16 @@ func (f *Field) Findable() bool {
 }
 
 func (f *Field) String() string {
+	return f.toString(0)
+}
+
+func (f *Field) toString(l int) string {
+	if l > 3 {
+		return "... more depth ..."
+	}
 	fields := make([]string, 0)
 	for _, f := range f.Fields {
-		fields = append(fields, f.String())
+		fields = append(fields, f.toString(l+1))
 	}
 
 	fieldsStr := strings.Join(fields, ", ")


### PR DESCRIPTION
As we are processing a struct, it might be that we hit that same struct again as a child. We can't process twice the same struct without falling into an infinite loop.

This change detects such case. It defers the point at which structs get their subfields until the end, because we don't know all of them beforehand, and for that we need an extra layer of indirection for the fields slice, because slice are immutable.