### PR TITLE
Adapt code generation to recursive types.

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -1,8 +1,6 @@
 package generator
 
-import (
-	"os"
-)
+import "os"
 
 type Generator struct {
 	filename string

--- a/generator/processor.go
+++ b/generator/processor.go
@@ -144,6 +144,7 @@ func (p *Processor) tryGetStruct(typ types.Type) *types.Struct {
 
 func (p *Processor) processStruct(name string, s *types.Struct) *Model {
 	m := NewModel(name)
+	m.CheckedNode = s
 
 	var base int
 	if base, m.Fields = p.getFields(s); base == -1 {

--- a/generator/templates/schema.tgo
+++ b/generator/templates/schema.tgo
@@ -1,32 +1,17 @@
 
 type schema struct {
-{{range .Models}}{{template "schemaDef" .}}
+{{range .Models}}{{$.GenType . ""}}
 {{end}}
 }
 
-{{define "schemaDef"}}{{if eq .Type "struct"}}{{if .ValidFields}}\
-    {{.Name}} {{.Type}}{
-        {{range .ValidFields}}{{template "schemaDef" .}}
-        {{end}}\
-    }\
-    {{end}}\
-{{else}}{{.Name}} storable.{{if .ContainsMap}}Map{{else}}Field{{end}}{{end}}{{end}}
+{{range $f := .Fields}}
+type {{.Name}} struct {
+{{range .Fields}}{{$.GenType . $f.Path}}
+{{end}}
+}
+{{end}}
 
 var Schema = schema{
-{{range .Models}}{{template "schemaVar" .}}
+{{range .Models}}{{$.GenVar . nil}}
 {{end}}
 }
-
-{{define "schemaVar"}}\
-    {{if eq .Type "struct"}}{{if .ValidFields}}{{template "schemaVarDef" .}}{
-        {{range .ValidFields}}{{template "schemaVar" .}}{{end}}
-    },
-    {{end}}{{else}}\
-    {{.Name}}: storable.{{if .ContainsMap}}NewMap{{else}}NewField{{end}}("{{.GetPath}}", "{{.FindableType}}"),
-    {{end}}\
-{{end}}
-
-{{define "schemaVarDef"}}{{.Name}}: struct{{if .ValidFields}}{
-    {{range .ValidFields}}{{template "schemaDef" .}}
-    {{end}}
-}{{end}}{{end}}


### PR DESCRIPTION
This moves logic from the `schema.tgo` template to plain Go methods, because we need to keep more information about the code generation to avoid infinite loops.