### PR TITLE
store.Must* methods

### DIFF
--- a/generator/templates/model.tgo
+++ b/generator/templates/model.tgo
@@ -21,7 +21,7 @@ func (s *{{.StoreName}}) Query() *{{.QueryName}} {
     return &{{.QueryName}}{*storable.NewBaseQuery()}
 }
 
-func (s *{{.StoreName}}) Find(query *{{.Name}}Query) (*{{.ResultSetName}}, error) {
+func (s *{{.StoreName}}) Find(query *{{.QueryName}}) (*{{.ResultSetName}}, error) {
     resultSet, err := s.Store.Find(query)
     if err != nil {
         return nil, err
@@ -30,6 +30,16 @@ func (s *{{.StoreName}}) Find(query *{{.Name}}Query) (*{{.ResultSetName}}, error
     return &{{.ResultSetName}}{*resultSet}, nil
 }
 
+func (s *{{.StoreName}}) MustFind(query *{{.QueryName}}) *{{.ResultSetName}} {
+    resultSet, err := s.Find(query)
+    if err != nil {
+        panic(err)
+    }
+
+    return resultSet
+}
+
+
 func (s *{{.StoreName}}) FindOne(query *{{.QueryName}}) (*{{.Name}}, error) {
     resultSet, err := s.Find(query)
     if err != nil {
@@ -37,6 +47,15 @@ func (s *{{.StoreName}}) FindOne(query *{{.QueryName}}) (*{{.Name}}, error) {
     }
 
     return resultSet.One()
+}
+
+func (s *{{.StoreName}}) MustFindOne(query *{{.QueryName}}) *{{.Name}} {
+    doc, err := s.FindOne(query)
+    if err != nil {
+        panic(err)
+    }
+
+    return doc
 }
 
 

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -52,10 +52,7 @@ func (s *MongoSuite) TestQuery_FindByFoo(c *C) {
 	c.Assert(err, IsNil)
 
 	q.AddCriteria(operators.Eq(Schema.MyModel.String, "bar"))
-	r, err = store.Find(q)
-	c.Assert(err, IsNil)
-
-	one, err := r.One()
+	one, err := store.MustFind(q).One()
 	c.Assert(one, IsNil)
 	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
The goal of the `Must` methods is simplify calls to `Find` and `FindOne` where the panic is something acceptable:

```go
rs, err := s.Find(q)
if err != nil {
   ...
}
docs, err := rs.All()
if err != nil {
   ...
}
```

to 

```go
docs, err := s.MustFind(q).All()
if err != nil {
   ...
}
```
