### PR TITLE
Fix recursivity handling.

### DIFF
--- a/generator/processor_test.go
+++ b/generator/processor_test.go
@@ -41,7 +41,8 @@ func (s *ProcessorSuite) TestRecursiveStruct(c *C) {
 	genPkg, err := prc.ProcessTypesPkg()
 
 	c.Assert(err, IsNil)
-	c.Assert(genPkg.Models[0].Fields[2].Fields[2], Equals, genPkg.Models[0].Fields[2], Commentf("direct type recursivity not handled correctly."))
+	c.Assert(genPkg.Models[0].Fields[2].Fields[2].CheckedNode, Equals, genPkg.Models[0].Fields[2].CheckedNode, Commentf("direct type recursivity not handled correctly."))
+	c.Assert(len(genPkg.Models[0].Fields[2].Fields[2].Fields), Equals, 0)
 }
 
 func (s *ProcessorSuite) TestDeepRecursiveStruct(c *C) {
@@ -71,5 +72,6 @@ func (s *ProcessorSuite) TestDeepRecursiveStruct(c *C) {
 	genPkg, err := prc.ProcessTypesPkg()
 
 	c.Assert(err, IsNil)
-	c.Assert(genPkg.Models[0].Fields[2].Fields[0].Fields[2], Equals, genPkg.Models[0].Fields[2], Commentf("direct type recursivity not handled correctly."))
+	c.Assert(genPkg.Models[0].Fields[2].Fields[0].Fields[2].CheckedNode, Equals, genPkg.Models[0].Fields[2].CheckedNode, Commentf("direct type recursivity not handled correctly."))
+	c.Assert(len(genPkg.Models[0].Fields[2].Fields[0].Fields[2].Fields), Equals, 0)
 }

--- a/generator/template.go
+++ b/generator/template.go
@@ -302,7 +302,7 @@ func (g callHooksGenerator) generateStoreHooks(model *Model) string {
 	for _, hook := range model.StoreHooks {
 		if hook.Before == g.before && g.actions[hook.Action] {
 			updateVar := ""
-			if g.upsert && hook.Before == false {
+			if g.upsert {
 				updateVar = "updated, "
 			}
 			ret += fmt.Sprintf(

--- a/tests/hooks/storable.go
+++ b/tests/hooks/storable.go
@@ -427,7 +427,7 @@ type schemaRecurR struct {
 }
 
 type schemaRecurMoreThings struct {
-	I storable.Map
+	I storable.Field
 }
 
 type schemaRecurMyFailer struct {
@@ -442,34 +442,55 @@ type schemaRecurThings struct {
 
 type schemaRecurRR2 struct {
 	Foo           storable.Field
-	R             *schemaRecurR
-	MoreThings    *schemaRecurMoreThings
-	MyFailer      *schemaRecurMyFailer
-	MyAfterFailer *schemaRecurMyAfterFailer
-	Things        *schemaRecurThings
+	R             *schemaRecurRR2R
+	MoreThings    *schemaRecurRR2MoreThings
+	MyFailer      *schemaRecurRR2MyFailer
+	MyAfterFailer *schemaRecurRR2MyAfterFailer
+	Things        *schemaRecurRR2Things
+}
+
+type schemaRecurRR2R struct {
+}
+
+type schemaRecurRR2MoreThings struct {
+	I storable.Field
+}
+
+type schemaRecurRR2MyFailer struct {
+}
+
+type schemaRecurRR2MyAfterFailer struct {
+}
+
+type schemaRecurRR2Things struct {
+	I storable.Map
 }
 
 var Schema = schema{
 	Recur: &schemaRecur{
-		Foo: storable.NewField("-.r2.foo", "string"),
+		Foo: storable.NewField("foo", "string"),
 		R: &schemaRecurR{
-			Name: storable.NewField("r2.-.name", "string"),
+			Name: storable.NewField("-.name", "string"),
 			R2: &schemaRecurRR2{
 				Foo: storable.NewField("-.r2.foo", "string"),
-				R:   nil,
-				MoreThings: &schemaRecurMoreThings{
-					I: storable.NewMap("-.r2.things.[map].i", "int"),
+				R:   &schemaRecurRR2R{},
+				MoreThings: &schemaRecurRR2MoreThings{
+					I: storable.NewField("-.r2.morethings.i", "int"),
 				},
-				MyFailer:      &schemaRecurMyFailer{},
-				MyAfterFailer: &schemaRecurMyAfterFailer{},
-				Things: &schemaRecurThings{
+				MyFailer:      &schemaRecurRR2MyFailer{},
+				MyAfterFailer: &schemaRecurRR2MyAfterFailer{},
+				Things: &schemaRecurRR2Things{
 					I: storable.NewMap("-.r2.things.[map].i", "int"),
 				},
 			},
 		},
-		MoreThings:    nil,
-		MyFailer:      nil,
-		MyAfterFailer: nil,
-		Things:        nil,
+		MoreThings: &schemaRecurMoreThings{
+			I: storable.NewField("morethings.i", "int"),
+		},
+		MyFailer:      &schemaRecurMyFailer{},
+		MyAfterFailer: &schemaRecurMyAfterFailer{},
+		Things: &schemaRecurThings{
+			I: storable.NewMap("things.[map].i", "int"),
+		},
 	},
 }

--- a/tests/storable.go
+++ b/tests/storable.go
@@ -286,13 +286,13 @@ type schemaMyModelNestedRef struct {
 type schemaMyModelNested struct {
 	X       storable.Field
 	Y       storable.Field
-	Another *schemaMyModelNestedRefAnother
+	Another *schemaMyModelNestedAnother
 }
 
 type schemaMyModelNestedSlice struct {
 	X       storable.Field
 	Y       storable.Field
-	Another *schemaMyModelNestedRefAnother
+	Another *schemaMyModelNestedSliceAnother
 }
 
 type schemaMyModelInlineStruct struct {
@@ -305,10 +305,25 @@ type schemaMyModelNestedRefAnother struct {
 	Y storable.Field
 }
 
+type schemaMyModelNestedAnother struct {
+	X storable.Field
+	Y storable.Field
+}
+
+type schemaMyModelNestedSliceAnother struct {
+	X storable.Field
+	Y storable.Field
+}
+
 type schemaMyModelInlineStructMapOfSomeType struct {
-	X       storable.Field
-	Y       storable.Field
-	Another *schemaMyModelNestedRefAnother
+	X       storable.Map
+	Y       storable.Map
+	Another *schemaMyModelInlineStructMapOfSomeTypeAnother
+}
+
+type schemaMyModelInlineStructMapOfSomeTypeAnother struct {
+	X storable.Map
+	Y storable.Map
 }
 
 var Schema = schema{
@@ -322,22 +337,28 @@ var Schema = schema{
 		Slice:      storable.NewField("slice", "string"),
 		SliceAlias: storable.NewField("slicealias", "string"),
 		NestedRef: &schemaMyModelNestedRef{
-			X: storable.NewField("nestedslice.x", "int"),
-			Y: storable.NewField("nestedslice.y", "int"),
+			X: storable.NewField("nestedref.x", "int"),
+			Y: storable.NewField("nestedref.y", "int"),
 			Another: &schemaMyModelNestedRefAnother{
-				X: storable.NewField("nestedslice.another.x", "int"),
-				Y: storable.NewField("nestedslice.another.y", "int"),
+				X: storable.NewField("nestedref.another.x", "int"),
+				Y: storable.NewField("nestedref.another.y", "int"),
 			},
 		},
 		Nested: &schemaMyModelNested{
-			X:       storable.NewField("nestedslice.x", "int"),
-			Y:       storable.NewField("nestedslice.y", "int"),
-			Another: nil,
+			X: storable.NewField("nested.x", "int"),
+			Y: storable.NewField("nested.y", "int"),
+			Another: &schemaMyModelNestedAnother{
+				X: storable.NewField("nested.another.x", "int"),
+				Y: storable.NewField("nested.another.y", "int"),
+			},
 		},
 		NestedSlice: &schemaMyModelNestedSlice{
-			X:       storable.NewField("nestedslice.x", "int"),
-			Y:       storable.NewField("nestedslice.y", "int"),
-			Another: nil,
+			X: storable.NewField("nestedslice.x", "int"),
+			Y: storable.NewField("nestedslice.y", "int"),
+			Another: &schemaMyModelNestedSliceAnother{
+				X: storable.NewField("nestedslice.another.x", "int"),
+				Y: storable.NewField("nestedslice.another.y", "int"),
+			},
 		},
 		AliasOfString: storable.NewField("aliasofstring", "string"),
 		Time:          storable.NewField("time", "time.Time"),
@@ -345,9 +366,12 @@ var Schema = schema{
 		InlineStruct: &schemaMyModelInlineStruct{
 			MapOfString: storable.NewMap("inlinestruct.mapofstring.[map]", "string"),
 			MapOfSomeType: &schemaMyModelInlineStructMapOfSomeType{
-				X:       storable.NewField("nestedslice.x", "int"),
-				Y:       storable.NewField("nestedslice.y", "int"),
-				Another: nil,
+				X: storable.NewMap("inlinestruct.mapofsometype.[map].x", "int"),
+				Y: storable.NewMap("inlinestruct.mapofsometype.[map].y", "int"),
+				Another: &schemaMyModelInlineStructMapOfSomeTypeAnother{
+					X: storable.NewMap("inlinestruct.mapofsometype.[map].another.x", "int"),
+					Y: storable.NewMap("inlinestruct.mapofsometype.[map].another.y", "int"),
+				},
 			},
 		},
 	},


### PR DESCRIPTION
We were using a global map where we stored all the fields for every struct; this ensured that all structs were processed only once (correctly preventing recursivity loops), but had the unpleasant effect that only _the first_ processed field was injected in _every place_ its type was used.

This fixes that, by handling recursivity with a stack that grows and dies with the call stack, thus preventing that bug. (Plus, is significantly simpler.)

Oh, and tests pass now.