### PR TITLE
Fix Query.Sort returning gibberish when using more than one key.

### DIFF
--- a/common.go
+++ b/common.go
@@ -67,8 +67,8 @@ type FieldSort struct {
 	D Dir
 }
 
-// Mgo returns a representation of Sort compatible with the format of mgo.
-func (s Sort) MgoFormat() []string {
+// ToList returns a representation of Sort compatible with the format of mgo.
+func (s Sort) ToList() []string {
 	var fields []string
 	for _, fs := range s {
 		f := ""

--- a/common.go
+++ b/common.go
@@ -67,8 +67,8 @@ type FieldSort struct {
 	D Dir
 }
 
-// String returns a representation of Sort compatible with the format of mgo.
-func (s Sort) String() string {
+// Mgo returns a representation of Sort compatible with the format of mgo.
+func (s Sort) MgoFormat() []string {
 	var fields []string
 	for _, fs := range s {
 		f := ""
@@ -81,7 +81,7 @@ func (s Sort) String() string {
 		fields = append(fields, f)
 	}
 
-	return strings.Join(fields, ",")
+	return fields
 }
 
 // IsEmpty returns if this sort map is empty or not

--- a/common_test.go
+++ b/common_test.go
@@ -36,15 +36,15 @@ func (s *BaseSuite) TestMap_Key(c *C) {
 	c.Assert(f.Type(), Equals, "string")
 }
 
-func (s *BaseSuite) TestSort_String(c *C) {
+func (s *BaseSuite) TestSort_MgoFormat(c *C) {
 	sort := Sort{{NewField("foo", ""), Asc}}
-	c.Assert(sort.String(), Equals, "foo")
+	c.Assert(sort.MgoFormat(), DeepEquals, []string{"foo"})
 
 	sort = Sort{{NewField("foo", ""), Desc}}
-	c.Assert(sort.String(), Equals, "-foo")
+	c.Assert(sort.MgoFormat(), DeepEquals, []string{"-foo"})
 
-	sort = Sort{{NewField("foo", ""), Asc}, {Field{"qux", ""}, Desc}}
-	c.Assert(sort.String(), Equals, "foo,-qux")
+	sort = Sort{{NewField("foo", ""), Asc}, {NewField("qux", ""), Desc}}
+	c.Assert(sort.MgoFormat(), DeepEquals, []string{"foo", "-qux"})
 }
 
 func (s *BaseSuite) TestSort_IsEmpty(c *C) {

--- a/common_test.go
+++ b/common_test.go
@@ -36,15 +36,15 @@ func (s *BaseSuite) TestMap_Key(c *C) {
 	c.Assert(f.Type(), Equals, "string")
 }
 
-func (s *BaseSuite) TestSort_MgoFormat(c *C) {
+func (s *BaseSuite) TestSort_ToList(c *C) {
 	sort := Sort{{NewField("foo", ""), Asc}}
-	c.Assert(sort.MgoFormat(), DeepEquals, []string{"foo"})
+	c.Assert(sort.ToList(), DeepEquals, []string{"foo"})
 
 	sort = Sort{{NewField("foo", ""), Desc}}
-	c.Assert(sort.MgoFormat(), DeepEquals, []string{"-foo"})
+	c.Assert(sort.ToList(), DeepEquals, []string{"-foo"})
 
 	sort = Sort{{NewField("foo", ""), Asc}, {NewField("qux", ""), Desc}}
-	c.Assert(sort.MgoFormat(), DeepEquals, []string{"foo", "-qux"})
+	c.Assert(sort.ToList(), DeepEquals, []string{"foo", "-qux"})
 }
 
 func (s *BaseSuite) TestSort_IsEmpty(c *C) {

--- a/store.go
+++ b/store.go
@@ -100,7 +100,7 @@ func (s *Store) Find(q Query) (*ResultSet, error) {
 	mq := c.Find(q.GetCriteria())
 
 	if !q.GetSort().IsEmpty() {
-		mq.Sort(q.GetSort().String())
+		mq.Sort(q.GetSort().MgoFormat()...)
 	}
 
 	if q.GetSkip() != 0 {

--- a/store.go
+++ b/store.go
@@ -100,7 +100,7 @@ func (s *Store) Find(q Query) (*ResultSet, error) {
 	mq := c.Find(q.GetCriteria())
 
 	if !q.GetSort().IsEmpty() {
-		mq.Sort(q.GetSort().MgoFormat()...)
+		mq.Sort(q.GetSort().ToList()...)
 	}
 
 	if q.GetSkip() != 0 {

--- a/tests/store.go
+++ b/tests/store.go
@@ -1,6 +1,10 @@
 package tests
 
-import "gopkg.in/tyba/storable.v1"
+import (
+	"time"
+
+	"gopkg.in/tyba/storable.v1"
+)
 
 type StoreFixture struct {
 	storable.Document `bson:",inline" collection:"store"`
@@ -14,4 +18,11 @@ type StoreWithConstructFixture struct {
 
 func newStoreWithConstructFixture(f string) *StoreWithConstructFixture {
 	return &StoreWithConstructFixture{Foo: f}
+}
+
+type MultiKeySortFixture struct {
+	storable.Document `bson:",inline" collection:"query"`
+	Name              string
+	Start             time.Time
+	End               time.Time
 }

--- a/tests/store_test.go
+++ b/tests/store_test.go
@@ -128,8 +128,8 @@ func (s *MongoSuite) TestMultiKeySort(c *C) {
 
 	q := store.Query()
 	q.Sort(storable.Sort{
-		storable.FieldSort{storable.NewField("end", ""), storable.Desc},
-		storable.FieldSort{storable.NewField("start", ""), storable.Desc},
+		storable.FieldSort{Schema.MultiKeySortFixture.End, storable.Desc},
+		storable.FieldSort{Schema.MultiKeySortFixture.Start, storable.Desc},
 	})
 
 	set, err := store.Find(q)

--- a/tests/store_test.go
+++ b/tests/store_test.go
@@ -1,6 +1,11 @@
 package tests
 
-import . "gopkg.in/check.v1"
+import (
+	"time"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/tyba/storable.v1"
+)
 
 func (s *MongoSuite) TestStoreNew(c *C) {
 	store := NewStoreFixtureStore(s.db)
@@ -83,4 +88,59 @@ func (s *MongoSuite) TestStoreSave(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(updated, Equals, true)
 	c.Assert(store.MustFindOne(store.Query()).Foo, Equals, "bar")
+}
+
+func (s *MongoSuite) TestMultiKeySort(c *C) {
+	store := NewMultiKeySortFixtureStore(s.db)
+
+	var (
+		doc *MultiKeySortFixture
+		err error
+	)
+
+	doc = store.New()
+	doc.Name = "2015-2013"
+	doc.Start = time.Date(2005, 1, 2, 0, 0, 0, 0, time.UTC)
+	doc.End = time.Date(2013, 1, 2, 0, 0, 0, 0, time.UTC)
+	err = store.Insert(doc)
+	c.Assert(err, IsNil)
+
+	doc = store.New()
+	doc.Name = "2015-2012"
+	doc.Start = time.Date(2005, 1, 2, 0, 0, 0, 0, time.UTC)
+	doc.End = time.Date(2012, 4, 5, 0, 0, 0, 0, time.UTC)
+	err = store.Insert(doc)
+	c.Assert(err, IsNil)
+
+	doc = store.New()
+	doc.Name = "2002-2012"
+	doc.Start = time.Date(2002, 1, 2, 0, 0, 0, 0, time.UTC)
+	doc.End = time.Date(2012, 1, 2, 0, 0, 0, 0, time.UTC)
+	err = store.Insert(doc)
+	c.Assert(err, IsNil)
+
+	doc = store.New()
+	doc.Name = "2001-2012"
+	doc.Start = time.Date(2001, 1, 2, 0, 0, 0, 0, time.UTC)
+	doc.End = time.Date(2012, 1, 2, 0, 0, 0, 0, time.UTC)
+	err = store.Insert(doc)
+	c.Assert(err, IsNil)
+
+	q := store.Query()
+	q.Sort(storable.Sort{
+		storable.FieldSort{storable.NewField("end", ""), storable.Desc},
+		storable.FieldSort{storable.NewField("start", ""), storable.Desc},
+	})
+
+	set, err := store.Find(q)
+	c.Assert(err, IsNil)
+
+	documents, err := set.All()
+	c.Assert(err, IsNil)
+
+	c.Assert(documents, HasLen, 4)
+	c.Assert(documents[0].Name, Equals, "2015-2013")
+	c.Assert(documents[1].Name, Equals, "2015-2012")
+	c.Assert(documents[2].Name, Equals, "2002-2012")
+	c.Assert(documents[3].Name, Equals, "2001-2012")
 }


### PR DESCRIPTION
Storable wasn't returning a mgo compatible format string.

This change allows to use more than one key on `Query.Sort`.

Previously, translation was: `"-foo,bar"`, now it is `["-foo", "bar"]`.