### PR TITLE
Fix potential nil pointer dereference.

### DIFF
--- a/example/storable.go
+++ b/example/storable.go
@@ -20,8 +20,10 @@ func NewProductStore(db *mgo.Database) *ProductStore {
 // New returns a new instance of Product.
 func (s *ProductStore) New(name string, price Price, createdAt time.Time) (doc *Product, err error) {
 	doc, err = newProduct(name, price, createdAt)
-	doc.SetIsNew(true)
-	doc.SetId(bson.NewObjectId())
+	if doc != nil {
+		doc.SetIsNew(true)
+		doc.SetId(bson.NewObjectId())
+	}
 	return
 }
 

--- a/generator/templates/model.tgo
+++ b/generator/templates/model.tgo
@@ -13,8 +13,10 @@ func New{{.StoreName}}(db *mgo.Database) *{{.StoreName}} {
 // New returns a new instance of {{.Name}}.
 func (s *{{.StoreName}}) New({{.NewArgs}}) {{.NewReturns}} {
 	{{.NewRetVars}} = {{if .NewFunc}}{{.NewFunc.Name}}({{.NewArgVars}}){{else}}&{{.Name}}{}{{end}}
-    doc.SetIsNew(true)
-    doc.SetId(bson.NewObjectId())
+    if doc != nil {
+        doc.SetIsNew(true)
+        doc.SetId(bson.NewObjectId())
+    }
     return
 }
 

--- a/tests/storable.go
+++ b/tests/storable.go
@@ -18,8 +18,10 @@ func NewEventsFixtureStore(db *mgo.Database) *EventsFixtureStore {
 // New returns a new instance of EventsFixture.
 func (s *EventsFixtureStore) New() (doc *EventsFixture) {
 	doc = newEventsFixture()
-	doc.SetIsNew(true)
-	doc.SetId(bson.NewObjectId())
+	if doc != nil {
+		doc.SetIsNew(true)
+		doc.SetId(bson.NewObjectId())
+	}
 	return
 }
 
@@ -219,8 +221,10 @@ func NewEventsSaveFixtureStore(db *mgo.Database) *EventsSaveFixtureStore {
 // New returns a new instance of EventsSaveFixture.
 func (s *EventsSaveFixtureStore) New() (doc *EventsSaveFixture) {
 	doc = newEventsSaveFixture()
-	doc.SetIsNew(true)
-	doc.SetId(bson.NewObjectId())
+	if doc != nil {
+		doc.SetIsNew(true)
+		doc.SetId(bson.NewObjectId())
+	}
 	return
 }
 
@@ -578,8 +582,10 @@ func NewQueryFixtureStore(db *mgo.Database) *QueryFixtureStore {
 // New returns a new instance of QueryFixture.
 func (s *QueryFixtureStore) New(f string) (doc *QueryFixture) {
 	doc = newQueryFixture(f)
-	doc.SetIsNew(true)
-	doc.SetId(bson.NewObjectId())
+	if doc != nil {
+		doc.SetIsNew(true)
+		doc.SetId(bson.NewObjectId())
+	}
 	return
 }
 
@@ -751,8 +757,10 @@ func NewResultSetFixtureStore(db *mgo.Database) *ResultSetFixtureStore {
 // New returns a new instance of ResultSetFixture.
 func (s *ResultSetFixtureStore) New(f string) (doc *ResultSetFixture) {
 	doc = newResultSetFixture(f)
-	doc.SetIsNew(true)
-	doc.SetId(bson.NewObjectId())
+	if doc != nil {
+		doc.SetIsNew(true)
+		doc.SetId(bson.NewObjectId())
+	}
 	return
 }
 
@@ -924,8 +932,10 @@ func NewSchemaFixtureStore(db *mgo.Database) *SchemaFixtureStore {
 // New returns a new instance of SchemaFixture.
 func (s *SchemaFixtureStore) New() (doc *SchemaFixture) {
 	doc = &SchemaFixture{}
-	doc.SetIsNew(true)
-	doc.SetId(bson.NewObjectId())
+	if doc != nil {
+		doc.SetIsNew(true)
+		doc.SetId(bson.NewObjectId())
+	}
 	return
 }
 
@@ -1097,8 +1107,10 @@ func NewStoreFixtureStore(db *mgo.Database) *StoreFixtureStore {
 // New returns a new instance of StoreFixture.
 func (s *StoreFixtureStore) New() (doc *StoreFixture) {
 	doc = &StoreFixture{}
-	doc.SetIsNew(true)
-	doc.SetId(bson.NewObjectId())
+	if doc != nil {
+		doc.SetIsNew(true)
+		doc.SetId(bson.NewObjectId())
+	}
 	return
 }
 
@@ -1270,8 +1282,10 @@ func NewStoreWithConstructFixtureStore(db *mgo.Database) *StoreWithConstructFixt
 // New returns a new instance of StoreWithConstructFixture.
 func (s *StoreWithConstructFixtureStore) New(f string) (doc *StoreWithConstructFixture) {
 	doc = newStoreWithConstructFixture(f)
-	doc.SetIsNew(true)
-	doc.SetId(bson.NewObjectId())
+	if doc != nil {
+		doc.SetIsNew(true)
+		doc.SetId(bson.NewObjectId())
+	}
 	return
 }
 

--- a/tests/store.go
+++ b/tests/store.go
@@ -17,6 +17,9 @@ type StoreWithConstructFixture struct {
 }
 
 func newStoreWithConstructFixture(f string) *StoreWithConstructFixture {
+	if f == "" {
+		return nil
+	}
 	return &StoreWithConstructFixture{Foo: f}
 }
 

--- a/tests/store_test.go
+++ b/tests/store_test.go
@@ -44,6 +44,13 @@ func (s *MongoSuite) TestStoreMustFind(c *C) {
 	c.Assert(count, Equals, 2)
 }
 
+func (s *MongoSuite) TestStoreFailingOnNew(c *C) {
+	store := NewStoreWithConstructFixtureStore(s.db)
+
+	doc := store.New("")
+	c.Assert(doc, IsNil)
+}
+
 func (s *MongoSuite) TestStoreFindOne(c *C) {
 	store := NewStoreWithConstructFixtureStore(s.db)
 	c.Assert(store.Insert(store.New("bar")), IsNil)


### PR DESCRIPTION
Code generated by generator template could cause a nil pointer
dereference when a storable document had a failing construction.