### PR TITLE
Substitute escaping for raw string. NBC.

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -23,5 +23,5 @@ func (s *BaseSuite) TestBaseQuery_String(c *C) {
 	q.AddCriteria(bson.M{"foo": "foo"})
 	q.AddCriteria(bson.M{"qux": "qux"})
 
-	c.Assert(q.String(), Equals, "{\"$and\":[{\"foo\":\"foo\"},{\"qux\":\"qux\"}]}")
+	c.Assert(q.String(), Equals, `{"$and":[{"foo":"foo"},{"qux":"qux"}]}`)
 }


### PR DESCRIPTION
NBC == no behavior change.

It's just a minimal readability change.